### PR TITLE
refactor: 增加bluebird类库用来增强Promise对各个浏览器支持

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "scripts": {
     "start": "babel vue-lazyload.js -o vue-lazyload.es5.js"
   },
-  "dependencies": {},
+  "dependencies": {
+    "bluebird": "^3.3.5"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/hilongjw/vue-lazyload.git"
+    "url": "git+https://github.com/hilongjw/vue-lazyload.git"
   },
   "keywords": [
     "vue-lazyload",
@@ -17,7 +19,10 @@
     "lazyload",
     "vue-directive"
   ],
-  "author": "Awe <hilongjw@gmail.com>",
+  "author": {
+    "name": "Awe",
+    "email": "hilongjw@gmail.com"
+  },
   "bugs": {
     "url": "https://github.com/hilongjw/vue-lazyload/issues"
   },
@@ -25,5 +30,32 @@
   "devDependencies": {
     "babel-cli": "^6.4.5",
     "babel-preset-es2015": "^6.3.13"
-  }
+  },
+  "gitHead": "35044bcea38a2391be01dbb07431b451318abe74",
+  "homepage": "https://github.com/hilongjw/vue-lazyload#readme",
+  "_id": "vue-lazyload@0.4.0",
+  "_shasum": "1b00d8428534ffa44720e01cf2e3ac8ccf1680f1",
+  "_from": "vue-lazyload@",
+  "_npmVersion": "3.6.0",
+  "_nodeVersion": "5.7.0",
+  "_npmUser": {
+    "name": "imawe",
+    "email": "hilongjw@qq.com"
+  },
+  "dist": {
+    "shasum": "1b00d8428534ffa44720e01cf2e3ac8ccf1680f1",
+    "tarball": "https://registry.npmjs.org/vue-lazyload/-/vue-lazyload-0.4.0.tgz"
+  },
+  "maintainers": [
+    {
+      "name": "imawe",
+      "email": "hilongjw@qq.com"
+    }
+  ],
+  "_npmOperationalInternal": {
+    "host": "packages-12-west.internal.npmjs.com",
+    "tmp": "tmp/vue-lazyload-0.4.0.tgz_1459592003834_0.7160406508482993"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/vue-lazyload/-/vue-lazyload-0.4.0.tgz"
 }

--- a/vue-lazyload.es5.js
+++ b/vue-lazyload.es5.js
@@ -1,5 +1,11 @@
 'use strict';
 
+var _bluebird = require('bluebird');
+
+var _bluebird2 = _interopRequireDefault(_bluebird);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
 exports.install = function (Vue, options) {
     var init = {
         error: options.error,
@@ -84,7 +90,7 @@ exports.install = function (Vue, options) {
             item.el.setAttribute('style', item.bindType + ': url(' + init.loading + ')');
         }
 
-        return new Promise(function (resolve, reject) {
+        return new _bluebird2.default(function (resolve, reject) {
             var image = new Image();
             image.src = item.src;
 

--- a/vue-lazyload.js
+++ b/vue-lazyload.js
@@ -1,3 +1,4 @@
+import Promise from 'bluebird'
 exports.install = function (Vue, options) {
     const init = {
         error: options.error,


### PR DESCRIPTION
不知道webpack还是你的domo从插件外部提供了Promise的兼容，我的项目中没有使用webpack，为了兼容低版本浏览器，感觉在插件外部单独require bluebird的方式只为了兼容vue-lazyload中Promise的使用的方式不太好，遂做简单修改，在插件内容实现兼容，作者可酌情合并！