### PR TITLE
修正当列表不在 window 上滚动时无法工作的 bug

### DIFF
--- a/vue-lazyload.js
+++ b/vue-lazyload.js
@@ -137,19 +137,21 @@ exports.install = function (Vue, options) {
     Vue.directive('lazy', {
         bind: function() {
             if (!init.hasbind) {
-                if(document.getElementById(Object.keys(this.modifiers)[0])) {
-                    init.isInChild = true
-                    init.childEl = document.getElementById(Object.keys(this.modifiers)[0])
-                }
-                init.hasbind = true
-                if(init.isInChild) {
-                    init.childEl.addEventListener('scroll', lazyLoadHandler)
-                }
-                window.addEventListener('scroll', lazyLoadHandler)
-                window.addEventListener('wheel', lazyLoadHandler)
-                window.addEventListener('mousewheel', lazyLoadHandler)
-                window.addEventListener('resize', lazyLoadHandler)
-                lazyLoadHandler()
+                Vue.nextTick(() => {
+                    if(document.getElementById(Object.keys(this.modifiers)[0])) {
+                      init.isInChild = true
+                      init.childEl = document.getElementById(Object.keys(this.modifiers)[0])
+                    }
+                    init.hasbind = true
+                    if(init.isInChild) {
+                      init.childEl.addEventListener('scroll', lazyLoadHandler)
+                    }
+                    window.addEventListener('scroll', lazyLoadHandler)
+                    window.addEventListener('wheel', lazyLoadHandler)
+                    window.addEventListener('mousewheel', lazyLoadHandler)
+                    window.addEventListener('resize', lazyLoadHandler)
+                    lazyLoadHandler()
+                })
             }
         },
         update: function(newValue, oldValue) {
@@ -160,10 +162,10 @@ exports.install = function (Vue, options) {
                 this.el.setAttribute('style', this.arg + ': url(' + init.loading + ')')
             }
             let parentEl = null
-            if(document.getElementById(Object.keys(this.modifiers)[0])) {
-                parentEl = document.getElementById(Object.keys(this.modifiers)[0])
-            }
             this.vm.$nextTick(() => {
+                if(document.getElementById(Object.keys(this.modifiers)[0])) {
+                  parentEl = document.getElementById(Object.keys(this.modifiers)[0])
+                }
                 let pos = getPosition(this.el)
                 listeners.push({
                     bindType: this.arg,


### PR DESCRIPTION
Hi，@hilongjw！和 #13 描述的一样，当列表的容器有固定高度且 overflow 为 scroll 时，v-lazy 好像不能正常工作。我试着在两处涉及列表容器操作的地方加了 nextTick，目前我这里可以正常运行了。请验证，谢谢！