### PR TITLE
修复一个问题

### DIFF
--- a/vue-lazyload.js
+++ b/vue-lazyload.js
@@ -116,6 +116,7 @@ exports.install = function (Vue, options) {
         }
 
         if (listeners.length == 0) {
+            init.hasbind = false;
             window.removeEventListener('scroll', lazyLoadHandler)
             window.removeEventListener('wheel', lazyLoadHandler)
             window.removeEventListener('mousewheel', lazyLoadHandler)


### PR DESCRIPTION
https://github.com/ElemeFE/mint-ui/issues/134
当所有图片全部加载完毕的前提下，退出页面时将 `init.hasbind` 初始化，确保下次进入时能够正确 bind