### PR TITLE
Add an option name 'scrollElement' in order to allow user to set the scrolling container element.

### DIFF
--- a/vue-lazyload.es5.js
+++ b/vue-lazyload.es5.js
@@ -6,12 +6,14 @@ exports.install = function (Vue, Options) {
     var isVueNext = Vue.version.split('.')[0] === '2';
     var DEFAULT_PRE = 1.3;
     var DEFAULT_URL = 'data:img/jpg;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEXs7Oxc9QatAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJggg==';
+    var DEFAULT_SCROLLELEMENT = window;
     if (!Options) {
         Options = {
             preLoad: DEFAULT_PRE,
             error: DEFAULT_URL,
             loading: DEFAULT_URL,
-            try: 3
+            try: 3,
+            scrollElement: DEFAULT_SCROLLELEMENT
         };
     }
     var Init = {
@@ -19,7 +21,8 @@ exports.install = function (Vue, Options) {
         error: Options.error ? Options.error : DEFAULT_URL,
         loading: Options.loading ? Options.loading : DEFAULT_URL,
         hasbind: false,
-        try: Options.try ? Options.try : 1
+        try: Options.try ? Options.try : 1,
+        scrollElement: Options.scrollElement || DEFAULT_SCROLLELEMENT
     };
 
     var Listeners = [];
@@ -50,11 +53,23 @@ exports.install = function (Vue, Options) {
     };
 
     var _ = {
-        on: function on(type, func) {
-            window.addEventListener(type, func);
+        on: function on(type, func, element) {
+            if (typeof element === 'undefined') {
+                window.addEventListener(type, func);
+            } else if (typeof element.length !== 'undefined' && element.length > 0) {
+                element[0].addEventListener(type, func);
+            } else {
+                element.addEventListener(type, func);
+            }
         },
-        off: function off(type, func) {
-            window.removeEventListener(type, func);
+        off: function off(type, func, element) {
+            if (typeof element === 'undefined') {
+                window.removeEventListener(type, func);
+            } else if (typeof element.length !== 'undefined' && element.length > 0) {
+                element[0].removeEventListener(type, func);
+            } else {
+                element.removeEventListener(type, func);
+            }
         }
     };
 
@@ -68,13 +83,13 @@ exports.install = function (Vue, Options) {
 
     var onListen = function onListen(start) {
         if (start) {
-            _.on('scroll', lazyLoadHandler);
+            _.on('scroll', lazyLoadHandler, Init.scrollElement);
             _.on('wheel', lazyLoadHandler);
             _.on('mousewheel', lazyLoadHandler);
             _.on('resize', lazyLoadHandler);
         } else {
             Init.hasbind = false;
-            _.off('scroll', lazyLoadHandler);
+            _.off('scroll', lazyLoadHandler, Init.scrollElement);
             _.off('wheel', lazyLoadHandler);
             _.off('mousewheel', lazyLoadHandler);
             _.off('resize', lazyLoadHandler);

--- a/vue-lazyload.js
+++ b/vue-lazyload.js
@@ -4,12 +4,14 @@ exports.install = function(Vue, Options) {
     const isVueNext = Vue.version.split('.')[0] === '2'
     const DEFAULT_PRE = 1.3
     const DEFAULT_URL = 'data:img/jpg;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEXs7Oxc9QatAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJggg=='
+    const DEFAULT_SCROLLELEMENT = window
     if (!Options) {
         Options = {
             preLoad: DEFAULT_PRE,
             error: DEFAULT_URL,
             loading: DEFAULT_URL,
-            try: 3
+            try: 3,
+            scrollElement: DEFAULT_SCROLLELEMENT
         }
     }
     const Init = {
@@ -17,7 +19,8 @@ exports.install = function(Vue, Options) {
         error: Options.error ? Options.error : DEFAULT_URL,
         loading: Options.loading ? Options.loading : DEFAULT_URL,
         hasbind: false,
-        try: Options.try ? Options.try : 1
+        try: Options.try ? Options.try : 1,
+        scrollElement: Options.scrollElement || DEFAULT_SCROLLELEMENT
     }
 
     const Listeners = []
@@ -49,11 +52,23 @@ exports.install = function(Vue, Options) {
     }
 
     const _ = {
-        on (type, func) {
-            window.addEventListener(type, func)
+        on (type, func, element) {
+            if (typeof element === 'undefined') {
+                window.addEventListener(type, func);
+            } else if (typeof element.length !== 'undefined' && element.length > 0) {
+                element[0].addEventListener(type, func);
+            } else {
+                element.addEventListener(type, func);
+            }
         },
-        off (type, func) {
-            window.removeEventListener(type, func)
+        off (type, func, element) {
+            if (typeof element === 'undefined') {
+                window.removeEventListener(type, func);
+            } else if (typeof element.length !== 'undefined' && element.length > 0) {
+                element[0].removeEventListener(type, func);
+            } else {
+                element.removeEventListener(type, func);
+            }
         },
     }
 
@@ -67,13 +82,13 @@ exports.install = function(Vue, Options) {
 
     const onListen = (start) => {
         if (start) {
-            _.on('scroll', lazyLoadHandler)
+            _.on('scroll', lazyLoadHandler, Init.scrollElement)
             _.on('wheel', lazyLoadHandler)
             _.on('mousewheel', lazyLoadHandler)
             _.on('resize', lazyLoadHandler)
         } else {
             Init.hasbind = false
-            _.off('scroll', lazyLoadHandler)
+            _.off('scroll', lazyLoadHandler, Init.scrollElement)
             _.off('wheel', lazyLoadHandler)
             _.off('mousewheel', lazyLoadHandler)
             _.off('resize', lazyLoadHandler)


### PR DESCRIPTION
to fix this: 'scroll' tigger didn't work well in my project because my scrolling container is not 'window'.
So I add an option name 'scrollElement' in order to allow user to set the scrolling container element. Of course this option is not required.

e.g:

	Vue.use(VueLazyload, {
	  preLoad: 2,
	  error: 'static/lazyerror.png',
	  loading: 'static/lazyloading.png',
	  try: 3,
	  scrollElement: document.getElementById('#MainContainer')
	  // or
	  // scrollElement: document.getElementsByClassName('scroll')
	})