### PR TITLE
using new Date().getTime() instead of hacky + new Date()

### DIFF
--- a/vue-lazyload.js
+++ b/vue-lazyload.js
@@ -38,7 +38,7 @@ export default (Vue, Options = {}) => {
             let context = this
             let args = arguments
             let runCallback = function () {
-                    lastRun = +new Date()
+                    lastRun = new Date().getTime()
                     timeout = false
                     action.apply(context, args)
                 }


### PR DESCRIPTION
new Date().getTime() is more readable and slightly more performant (according to http://stackoverflow.com/questions/14255664/new-date-is-this-good-practice)