### PR TITLE
Customise Events to Listen To

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,24 @@ vm.$Lazyload.$on('loaded', handler)
 vm.$Lazyload.$off('loaded', handler)
 ```
 
+# Desired Listen Events
+
+You can configure which events you want vue-lazyload by passing in an array
+of listener names.
+
+```
+Vue.use(VueLazyload, {
+  preLoad: 1.3,
+  error: 'dist/error.png',
+  loading: 'dist/loading.gif',
+  attempt: 1,
+  // the default is ['scroll', 'wheel', 'mousewheel', 'resize', 'animationend', 'transitionend']
+  listenEvents: [ 'scroll' ]
+})
+```
+
+This is useful if you are having trouble with this plugin resetting itself to loading
+when you have certain animations and transitions taking place
 
 
 # License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-lazyload",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Vue module for lazy-loading images in your vue.js applications.",
   "main": "vue-lazyload.es5.js",
   "scripts": {

--- a/vue-lazyload.es5.js
+++ b/vue-lazyload.es5.js
@@ -26,7 +26,7 @@ var vueLazyload = (function (Vue) {
 
     var isVueNext = Vue.version.split('.')[0] === '2';
     var DEFAULT_URL = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-    var ListenEvents = ['scroll', 'wheel', 'mousewheel', 'resize', 'animationend', 'transitionend'];
+    var ListenEvents = Options.listenEvents || ['scroll', 'wheel', 'mousewheel', 'resize', 'animationend', 'transitionend'];
 
     var $Lazyload = {
         listeners: {

--- a/vue-lazyload.js
+++ b/vue-lazyload.js
@@ -13,7 +13,7 @@ if (!Array.prototype.$remove) {
 export default (Vue, Options = {}) => {
     const isVueNext = Vue.version.split('.')[0] === '2'
     const DEFAULT_URL = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
-    const ListenEvents = ['scroll', 'wheel', 'mousewheel', 'resize', 'animationend', 'transitionend']
+    const ListenEvents = Options.listenEvents || ['scroll', 'wheel', 'mousewheel', 'resize', 'animationend', 'transitionend']
 
     const $Lazyload = {
         listeners: {


### PR DESCRIPTION
I was having issues with the plugin sometimes resetting back to loading state at the end of certain animations.

Making this value configurable has allowed me to resolve my problem, and this may come in handy for others in the future.

I have updated both the es5 and es6 versions, and have bumped the version by 1 revision.

I have also updated the README file with information on how and why this functionality is now available.

Thanks for a great plugin