### PR TITLE
Add image width and height `data-` attributes for background images

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,15 @@ data: {
 ```
 
 
-Elemet with background-image 
+Elemet with background-image. This gets the original image size set onto
+the element with data attributes, which may be  useful if you are doing
+anything with `background-size: cover`
 
 ```html
 <div v-lazy:background-image="img" ></div>
 
 <!-- rendered-->
-<div style="background-image: url(dist/test3.jpg)"></div>
+<div style="background-image: url(dist/test3.jpg)" data-width="400" data-height="200"></div>
 ```
 
 Customer scrollable element

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-lazyload",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Vue module for lazy-loading images in your vue.js applications.",
   "main": "vue-lazyload.es5.js",
   "scripts": {

--- a/vue-lazyload.es5.js
+++ b/vue-lazyload.es5.js
@@ -131,11 +131,15 @@ var vueLazyload = (function (Vue) {
         }
     };
 
-    var setElRender = function setElRender(el, bindType, src, state, context) {
+    var setElRender = function setElRender(el, bindType, src, state, context, imageAttributes) {
         if (!bindType) {
             el.setAttribute('src', src);
         } else {
             el.style[bindType] = 'url(' + src + ')';
+            if (imageAttributes) {
+                el.setAttribute('data-width', imageAttributes.naturalWidth)
+                el.setAttribute('data-height', imageAttributes.naturalHeight)
+            }
         }
         el.setAttribute('lazy', state);
         if (context) {
@@ -150,8 +154,8 @@ var vueLazyload = (function (Vue) {
         if (imageCache.indexOf(item.src) !== -1) return setElRender(item.el, item.bindType, item.src, 'loaded');
         imageCache.push(item.src);
 
-        loadImageAsync(item, function (image) {
-            setElRender(item.el, item.bindType, item.src, 'loaded', item);
+        loadImageAsync(item, function(image) {
+            setElRender(item.el, item.bindType, item.src, 'loaded', item, image);
             Listeners.$remove(item);
         }, function (error) {
             imageCache.$remove(item.src);

--- a/vue-lazyload.es5.js
+++ b/vue-lazyload.es5.js
@@ -154,7 +154,7 @@ var vueLazyload = (function (Vue) {
         if (imageCache.indexOf(item.src) !== -1) return setElRender(item.el, item.bindType, item.src, 'loaded');
         imageCache.push(item.src);
 
-        loadImageAsync(item, function(image) {
+        loadImageAsync(item, function (image) {
             setElRender(item.el, item.bindType, item.src, 'loaded', item, image);
             Listeners.$remove(item);
         }, function (error) {

--- a/vue-lazyload.js
+++ b/vue-lazyload.js
@@ -119,11 +119,15 @@ export default (Vue, Options = {}) => {
         }
     }
 
-    const setElRender = (el, bindType, src, state, context) => {
+    const setElRender = (el, bindType, src, state, context, imageAttributes) => {
         if (!bindType) {
             el.setAttribute('src', src)
         } else {
             el.style[bindType] = 'url(' + src + ')'
+            if (imageAttributes) {
+                el.setAttribute('data-width', imageAttributes.naturalWidth)
+                el.setAttribute('data-height', imageAttributes.naturalHeight)
+            }
         }
         el.setAttribute('lazy', state)
         if (context) {
@@ -139,7 +143,7 @@ export default (Vue, Options = {}) => {
         imageCache.push(item.src)
 
         loadImageAsync(item, (image) => {
-                setElRender(item.el, item.bindType, item.src, 'loaded', item)
+                setElRender(item.el, item.bindType, item.src, 'loaded', item, image)
                 Listeners.$remove(item)
             }, (error) => {
                 imageCache.$remove(item.src)


### PR DESCRIPTION
I needed to capture the width and height of an image loaded through this plugin so I made it that the plugin binds the width and height of the desired image onto the `data-width` and `data-height` attributes if the type of bind is a background image.

There might be a different name the project maintainers would like to use, please check on this @hilongjw 

Updated readme to reflect changes and bumped version.