### PR TITLE
Fixed scrset image loading

### DIFF
--- a/src/lazy.js
+++ b/src/lazy.js
@@ -28,7 +28,7 @@ export default function (Vue) {
                 error: error || DEFAULT_URL,
                 loading: loading || DEFAULT_URL,
                 attempt: attempt || 3,
-                scale: getDPR(scale),
+                scale: scale || getDPR(scale),
                 ListenEvents: listenEvents || DEFAULT_EVENTS,
                 hasbind: false,
                 supportWebp: supportWebp(),
@@ -137,7 +137,7 @@ export default function (Vue) {
             const exist = find(this.ListenerQueue, item => item.el === el)
 
             exist && exist.src !== src && exist.update({
-                src,
+                src: exist.src,
                 loading,
                 error
             })


### PR DESCRIPTION
- Added scale as an option - to fix containerWidth calculations - as srcset srcs are in pxs and the containerwidth also in pxs we should't calculate the width based on the scale - that give us wrong widths.
I've also fixed the update function that was preventing the src to the url coming from getBestSelectionFromSrcset() function.