### PR TITLE
Update listener.js

### DIFF
--- a/src/listener.js
+++ b/src/listener.js
@@ -128,6 +128,7 @@ export default class ReactiveListener {
         }
 
         if (this.state.loaded || imageCache[this.src]) {
+            this.state.loaded = true
             return this.render('loaded', true)
         }
 


### PR DESCRIPTION
相同的图片会从缓存中取，但是loaded没设置为true会再走一遍流程，在一些安卓低版本的机型background-image重新设置会再次发送请求