### PR TITLE
fix: check IntersectionObserver wrong

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,26 @@
 import assign from 'assign-deep'
 
 const inBrowser = typeof window !== 'undefined'
-export const hasIntersectionObserver = inBrowser && 'IntersectionObserver' in window
+export const hasIntersectionObserver = checkIntersectionObserver()
+
+function checkIntersectionObserver () {
+  if ('IntersectionObserver' in window &&
+    'IntersectionObserverEntry' in window &&
+    'intersectionRatio' in window.IntersectionObserverEntry.prototype) {
+  // Minimal polyfill for Edge 15's lack of `isIntersecting`
+  // See: https://github.com/w3c/IntersectionObserver/issues/211
+    if (!('isIntersecting' in window.IntersectionObserverEntry.prototype)) {
+      Object.defineProperty(window.IntersectionObserverEntry.prototype,
+        'isIntersecting', {
+          get: function () {
+            return this.intersectionRatio > 0
+          }
+        })
+    }
+    return true
+  }
+  return false
+}
 
 export const modeType = {
   event: 'event',


### PR DESCRIPTION
In some android device, like HUAWEI NXT-TL00, the check IntersectionObserver will return true, but lazy load can't work.

the pull request is base on  the W3C's polyfill in  https://github.com/w3c/IntersectionObserver/blob/master/polyfill/intersection-observer.js