### PR TITLE
Feature：self defined the name of lazyload path

### DIFF
--- a/src/lazy-container.js
+++ b/src/lazy-container.js
@@ -32,7 +32,8 @@ export default class LazyContainerMananger {
 }
 
 const defaultOptions = {
-  selector: 'img'
+  selector: 'img',
+  srcset: 'data-src'
 }
 
 class LazyContainer {
@@ -55,7 +56,7 @@ class LazyContainer {
     imgs.forEach(el => {
       this.lazy.add(el, assign({}, this.binding, {
         value: {
-          src: 'dataset' in el ? el.dataset.src : el.getAttribute('data-src'),
+          src: el.getAttribute(this.options.srcset),
           error: ('dataset' in el ? el.dataset.error : el.getAttribute('data-error')) || this.options.error,
           loading: ('dataset' in el ? el.dataset.loading : el.getAttribute('data-loading')) || this.options.loading
         }


### PR DESCRIPTION
Q: Why I want to add this feature?
A: Because in my project, i can' control the `img` tag, they come from the response data of my server api, and i can't know how many kinds.