### PR TITLE
fix: TypeError: item.destroy is not a function

### DIFF
--- a/src/lazy-component.js
+++ b/src/lazy-component.js
@@ -46,6 +46,9 @@ export default (lazy) => {
         this.show = true
         this.state.loaded = true
         this.$emit('show', this)
+      },
+      destroy () {
+        return this.$destroy
       }
     }
   }

--- a/src/lazy.js
+++ b/src/lazy.js
@@ -349,7 +349,7 @@ export default function (Vue) {
       })
       freeList.forEach(item => {
         remove(this.ListenerQueue, item)
-        item.$destroy()
+        item.destroy()
       })
     }
     /**

--- a/src/lazy.js
+++ b/src/lazy.js
@@ -349,7 +349,8 @@ export default function (Vue) {
       })
       freeList.forEach(item => {
         remove(this.ListenerQueue, item)
-        item.destroy()
+        const destroy = item.destroy || item.$destroy
+        destroy()
       })
     }
     /**

--- a/src/lazy.js
+++ b/src/lazy.js
@@ -349,7 +349,7 @@ export default function (Vue) {
       })
       freeList.forEach(item => {
         remove(this.ListenerQueue, item)
-        item.destroy()
+        item.$destroy()
       })
     }
     /**


### PR DESCRIPTION
I think Vue instances need `$destroy` to be destroyed.
issue: [#380](https://github.com/hilongjw/vue-lazyload/issues/380)