### PR TITLE
Fix: 377 Allow commas in urls on data-srcset

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -71,7 +71,7 @@ function getBestSelectionFromSrcset (el, scale) {
   let tmpSrc
   let tmpWidth
 
-  options = options.trim().split(',')
+  options = options.split(', ')
 
   options.map(item => {
     item = item.trim()


### PR DESCRIPTION
Regarding https://github.com/hilongjw/vue-lazyload/issues/377 

The previous code trimmed al the spaces and uses the commas to split, but urls can containn comas.

For example, Cloudinary (pretty use in the FE side) uses commas in their transformation paths like this: