### PR TITLE
Fix: 348 prevent to get null 404 (Not Found)

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -213,6 +213,7 @@ const _ = {
 
 const loadImageAsync = (item, resolve, reject) => {
   let image = new Image()
+  if (!item.src) return
   image.src = item.src
 
   image.onload = function () {


### PR DESCRIPTION
Added a validation at loadImageAsync() to prevent loaded null from item.src.