### PR TITLE
Update util.js

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -143,13 +143,11 @@ function supportWebp () {
   const d = document
 
   try {
-    let el = d.createElement('object')
-    el.type = 'image/webp'
-    el.style.visibility = 'hidden'
-    el.innerHTML = '!'
-    d.body.appendChild(el)
-    support = !el.offsetWidth
-    d.body.removeChild(el)
+    const elem = document.createElement('canvas');
+
+    if (!!(elem.getContext && elem.getContext('2d'))) {
+      support = elem.toDataURL('image/webp').indexOf('data:image/webp') === 0;
+    }
   } catch (err) {
     support = false
   }


### PR DESCRIPTION
Improve `supportWebp` function
Because previous code force Parse HTML, Recalculate Style and Layout on page load. It decrease Score in Page Speed Insight. We don't need to check each version of browser today, just most used