### PR TITLE
Fix issue 384: Capture the final operating state in the throttle function

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -157,8 +157,11 @@ function supportWebp () {
 
 function throttle (action, delay) {
   let timeout = null
+  let movement = null
   let lastRun = 0
+  let needRun = false
   return function () {
+    needRun = true
     if (timeout) {
       return
     }
@@ -174,6 +177,10 @@ function throttle (action, delay) {
       runCallback()
     } else {
       timeout = setTimeout(runCallback, delay)
+    }
+    if (needRun) {
+      clearTimeout(movement)
+      movement = setTimeout(runCallback, 2 * delay)
     }
   }
 }


### PR DESCRIPTION
fix issue #384
* Capture the final operating state in the `throttle` function