### PR TITLE
Fix lazy dir can't be registered when SSR

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,41 +5,42 @@ import LazyImage from './lazy-image'
 import { VueLazyloadOptions } from '../types/lazyload'
 import { App } from 'vue'
 
-export default {
-  /*
-  * install function
-  * @param  {Vue} Vue
-  * @param  {object} options lazyload options
-  */
-  install (Vue: App, options: VueLazyloadOptions = {}) {
-    const lazy = new Lazy(options)
-    const lazyContainer = new LazyContainer(lazy)
 
-    const vueVersion = Number(Vue.version.split('.')[0])
-    if (vueVersion < 3) return new Error('Vue version at least 3.0')
+/*
+* install function
+* @param  {Vue} Vue
+* @param  {object} options lazyload options
+*/
+const install = (Vue: App, options: VueLazyloadOptions = {}) => {
+  const lazy = new Lazy(options)
+  const lazyContainer = new LazyContainer(lazy)
 
-    Vue.config.globalProperties.$Lazyload = lazy
+  const vueVersion = Number(Vue.version.split('.')[0])
+  if (vueVersion < 3) return new Error('Vue version at least 3.0')
 
-    Vue.provide('Lazyload', lazy)
+  Vue.config.globalProperties.$Lazyload = lazy
 
-    if (options.lazyComponent) {
-      Vue.component('lazy-component', LazyComponent(lazy))
-    }
+  Vue.provide('Lazyload', lazy)
 
-    if (options.lazyImage) {
-      Vue.component('lazy-image', LazyImage(lazy))
-    }
-
-    Vue.directive('lazy', {
-      beforeMount: lazy.add.bind(lazy),
-      beforeUpdate: lazy.update.bind(lazy),
-      updated: lazy.lazyLoadHandler.bind(lazy),
-      unmounted: lazy.remove.bind(lazy)
-    })
-    Vue.directive('lazy-container', {
-      beforeMount: lazyContainer.bind.bind(lazyContainer),
-      updated: lazyContainer.update.bind(lazyContainer),
-      unmounted: lazyContainer.unbind.bind(lazyContainer)
-    })
+  if (options.lazyComponent) {
+    Vue.component('lazy-component', LazyComponent(lazy))
   }
+
+  if (options.lazyImage) {
+    Vue.component('lazy-image', LazyImage(lazy))
+  }
+
+  Vue.directive('lazy', {
+    beforeMount: lazy.add.bind(lazy),
+    beforeUpdate: lazy.update.bind(lazy),
+    updated: lazy.lazyLoadHandler.bind(lazy),
+    unmounted: lazy.remove.bind(lazy)
+  })
+  Vue.directive('lazy-container', {
+    beforeMount: lazyContainer.bind.bind(lazyContainer),
+    updated: lazyContainer.update.bind(lazyContainer),
+    unmounted: lazyContainer.unbind.bind(lazyContainer)
+  })
 }
+
+export { install }


### PR DESCRIPTION
Hey, the error detail is in #502 

I dive into the issue, it's because when we import `vue-lazyload` 
```js
import Lazyload from 'vue-lazyload'

console.log(Lazyload)
```

will get
```js
{
  default: {
    install
  }
}
```

if follow the instruction in readme
```js
App.use(Lazyload)
```
it can't be registered in Node env

So I modified the export from default export to named export to avoid this happen.

Please review, Thanks