### PR TITLE
fix: getSSRProps error

### DIFF
--- a/src/lazy-component.js
+++ b/src/lazy-component.js
@@ -27,6 +27,9 @@ const LazyComponent = (lazy) => {
       lazy.addLazyBox(this)
       lazy.lazyLoadHandler()
     },
+    getSSRProps () {
+      return {}
+    },
     beforeDestroy () {
       lazy.removeComponent(this)
     },

--- a/src/lazy-image.js
+++ b/src/lazy-image.js
@@ -58,6 +58,9 @@ const LazyImage = (lazyManager) => {
     beforeDestroy () {
       lazyManager.removeComponent(this)
     },
+    getSSRProps() {
+      return {}
+    },
     methods: {
       init () {
         const { src, loading, error } = lazyManager._valueFormatter(this.src)


### PR DESCRIPTION
#514 
在nuxt3 ssr渲染的时候会出现getSSRProps报错，即使按照nuxt3的插件使用方法声明当前文件仅在客户端渲染也仍旧会报错，后面看到nuxt3 团队对于这个问题的解决办法，是在插件里面增加一个getSSRProps方法。